### PR TITLE
Update deepracer_navigation_sim.launch.py

### DIFF
--- a/deepracer_bringup/launch/deepracer_navigation_sim.launch.py
+++ b/deepracer_bringup/launch/deepracer_navigation_sim.launch.py
@@ -25,7 +25,7 @@ from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
-    deepracer_bringup = get_package_share_directory('deepracer_bringup')
+    deepracer_bringup_dir = get_package_share_directory('deepracer_bringup')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time',
                                                             default='true')
     autostart = launch.substitutions.LaunchConfiguration('autostart')
@@ -67,7 +67,7 @@ def generate_launch_description():
 
         launch.actions.DeclareLaunchArgument(
             'params',
-            default_value=[deepracer_bringup,
+            default_value=[deepracer_bringup_dir,
                            '/config/nav2_params.yaml'],
             description='Full path to the ROS2 parameters file to use'),
 


### PR DESCRIPTION
Fixed code style of naming. 
I referred [deepracer_navigation_dr.launch](https://github.com/aws-deepracer/aws-deepracer/blob/0b59c0e2d6e7837338f3f20636d0fda92235195a/deepracer_bringup/launch/deepracer_navigation_dr.launch.py#L28). 
```
deepracer_bringup_dir = get_package_share_directory('deepracer_bringup')
```
It is better to unify the style of the repeated code.

