### PR TITLE
Correct package name while building Nav2 on the device

### DIFF
--- a/introduction-to-the-ros-navigation-stack-using-aws-deepracer-evo.md
+++ b/introduction-to-the-ros-navigation-stack-using-aws-deepracer-evo.md
@@ -276,7 +276,7 @@ rosws update
 **2.1.6 - Build the robot packages**
 
 ```
-cd ~/deepracer_nav2_ws/aws-deepracer/ && colcon build --packages-select deepracer_interfaces_pkg deepracer_bringup cmdvel_to_servo_pkg enable_deepracer_nav_pkg rf2o_laser_odometry rplidar_ros camera_pkg servo_pkg
+cd ~/deepracer_nav2_ws/aws-deepracer/ && colcon build --packages-select deepracer_interfaces_pkg deepracer_bringup cmdvel_to_servo_pkg enable_deepracer_nav_pkg rf2o_laser_odometry rplidar_ros2 camera_pkg servo_pkg
 
 ```
 


### PR DESCRIPTION
The folder name is `rplidar_ros` but the package name is actually `rplidar_ros2`.